### PR TITLE
Fixed small problem with validation

### DIFF
--- a/src/validators/transactionValidator.js
+++ b/src/validators/transactionValidator.js
@@ -20,7 +20,7 @@ const expensesTransactionSchema = Joi.object({
       "Entertainment",
       "Housing",
       "Technique",
-      "Communal, communications",
+      "Communal, communication",
       "Sports, hobbies",
       "Education",
       "Other"


### PR DESCRIPTION
Dodawanie transakcji z kategorii Communal, communication nie działało, bo nasza walidacja wymagała aby było z -s na końcu, poprawiłem.